### PR TITLE
fix `other-modules` in series.cabal

### DIFF
--- a/series.cabal
+++ b/series.cabal
@@ -62,7 +62,7 @@ library
     Data.Series
     Data.Series.Continuous
 
-  extra-modules:
+  other-modules:
     Data.Series.Internal
 
   hs-source-dirs:  src


### PR DESCRIPTION
### Summary
Investigate if `Series` should be a type class with instances `Discrete` and `Continuous`, where `Discrete` is the current version of `Series`.
### Results
The results of this investigation were inconclusive, the best course of action is to hold off on superclassing these two types until their functions converge.
### Tasks
- [x] Investigate.
- [x] Fix `other-modules` in `series.cabal`.